### PR TITLE
Add travis config to fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: java
 
 jdk:
   - oraclejdk8
+
+before_install:
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
Fix for #3:

With this travis configuration a virtual display is used while building. This is needed by some JavaFX classes. 
This should fix the travis build errors. 
