### PR TITLE
Handle negative delay times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: java
 
 jdk:
   - oraclejdk8
+
+before_install:
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start

--- a/src/main/java/rx/schedulers/JavaFxScheduler.java
+++ b/src/main/java/rx/schedulers/JavaFxScheduler.java
@@ -30,6 +30,8 @@ import rx.subscriptions.Subscriptions;
 
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.Math.max;
+
 /**
  * Executes work on the JavaFx UI thread.
  * This scheduler should only be used with actions that execute quickly.
@@ -42,12 +44,6 @@ public final class JavaFxScheduler extends Scheduler {
 
     public static JavaFxScheduler getInstance() {
         return INSTANCE;
-    }
-
-    private static void assertThatTheDelayIsValidForTheJavaFxTimer(long delay) {
-        if (delay < 0 || delay > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException(String.format("The JavaFx timer only accepts non-negative delays up to %d milliseconds.", Integer.MAX_VALUE));
-        }
     }
 
     @Override
@@ -71,10 +67,9 @@ public final class JavaFxScheduler extends Scheduler {
 
         @Override
         public Subscription schedule(final Action0 action, long delayTime, TimeUnit unit) {
-            long delay = unit.toMillis(delayTime);
-            assertThatTheDelayIsValidForTheJavaFxTimer(delay);
             final BooleanSubscription s = BooleanSubscription.create();
 
+            final long delay = unit.toMillis(max(delayTime, 0));
             final Timeline timeline = new Timeline(new KeyFrame(Duration.millis(delay), new EventHandler<ActionEvent>() {
 
                 @Override

--- a/src/test/java/rx/schedulers/JavaFxSchedulerTest.java
+++ b/src/test/java/rx/schedulers/JavaFxSchedulerTest.java
@@ -74,25 +74,6 @@ public final class JavaFxSchedulerTest {
     }
 
     @Test
-    public void testInvalidDelayValues() {
-        final JavaFxScheduler scheduler = new JavaFxScheduler();
-        final Worker inner = scheduler.createWorker();
-        final Action0 action = mock(Action0.class);
-
-        exception.expect(IllegalArgumentException.class);
-        inner.schedulePeriodically(action, -1L, 100L, TimeUnit.SECONDS);
-
-        exception.expect(IllegalArgumentException.class);
-        inner.schedulePeriodically(action, 100L, -1L, TimeUnit.SECONDS);
-
-        exception.expect(IllegalArgumentException.class);
-        inner.schedulePeriodically(action, 1L + Integer.MAX_VALUE, 100L, TimeUnit.MILLISECONDS);
-
-        exception.expect(IllegalArgumentException.class);
-        inner.schedulePeriodically(action, 100L, 1L + Integer.MAX_VALUE / 1000, TimeUnit.SECONDS);
-    }
-
-    @Test
     public void testPeriodicScheduling() throws Exception {
         final JavaFxScheduler scheduler = new JavaFxScheduler();
         final Worker inner = scheduler.createWorker();

--- a/src/test/java/rx/schedulers/JavaFxSchedulerTest.java
+++ b/src/test/java/rx/schedulers/JavaFxSchedulerTest.java
@@ -95,7 +95,7 @@ public final class JavaFxSchedulerTest {
 
         inner.schedulePeriodically(action, 50, 200, TimeUnit.MILLISECONDS);
 
-        if (!latch.await(5000, TimeUnit.MILLISECONDS)) {
+        if (!latch.await(1, TimeUnit.SECONDS)) {
             fail("timed out waiting for tasks to execute");
         }
 


### PR DESCRIPTION
Prior to this commit, `JavaFxScheduler` asserted that delay time values
must non-negative and less than `Integer.MAX_VALUE` for compatibility with
the JavaFX timer. This resulted in the possibility of false negative test
failures for `JavaFxSchedulerTest#testPeriodicScheduling`, because when the
system is under load (e.g. when CPUs are maxed out), negative delay time
values get passed to `#schedule`. These negative values are perfectly
valid, indicating no delay (and are documented as such--see
`Worker#schedule` Javadoc).

This commit removes the assertion of non-negative values, and instead
simply adapts any negative value to zero, which keeps the JavaFX timing
infrastructure happy. It also removes the upper boundary of
`Integer.MAX_VALUE` for delay times, as it does not appear that JavaFX
actually imposes any such limitation.

JavaFxSchedulerTest#testInvalidDelayValues has been removed entirely, as
there is essentially no such thing as an "invalid delay value" at this
point.

All remaining tests now typically succeed save for very infrequent failures
of `JavaFxSchedulerTest#testNestedActions`. The reason for these
non-deterministic failures is as yet unknown, but because they appear to be
unrelated to the changes addressed in this commit, no attempt is made here
to diagnose and fix them.

Note that this branch includes @lestard's pull request #4, which will
indeed be necessary to fix "display not found" errors under Travis CI's
headless environment. i.e. if that commit isn't included, this changes in
this commit won't have a chance of succeeding.
