### PR TITLE
Extra observables

### DIFF
--- a/src/main/java/rx/javafx/sources/ObservableListSource.java
+++ b/src/main/java/rx/javafx/sources/ObservableListSource.java
@@ -1,0 +1,41 @@
+package rx.javafx.sources;
+
+import java.util.List;
+
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.subscriptions.JavaFxSubscriptions;
+
+public class ObservableListSource {
+
+    /**
+     * @see rx.observables.JavaFxObservable#fromObservableList
+     */
+    public static <T> Observable<List<? extends T>> fromObservableList(ObservableList<T> list) {
+        return Observable.create(new Observable.OnSubscribe<List<? extends T>>() {
+            @Override
+            public void call(Subscriber<? super List<? extends T>> subscriber) {
+                subscriber.onNext(list);
+                
+                final ListChangeListener<T> listener = new ListChangeListener<T>() {
+                    @Override
+                    public void onChanged(Change<? extends T> change) {
+                        subscriber.onNext(change.getList());
+                    }
+                };
+                
+                list.addListener(listener);
+                
+                subscriber.add(JavaFxSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                    @Override
+                    public void call() {
+                        list.removeListener(listener);
+                    }
+                }));
+            }
+        });
+    }
+}

--- a/src/main/java/rx/javafx/sources/ObservableMapSource.java
+++ b/src/main/java/rx/javafx/sources/ObservableMapSource.java
@@ -1,0 +1,41 @@
+package rx.javafx.sources;
+
+import java.util.Map;
+
+import javafx.collections.MapChangeListener;
+import javafx.collections.ObservableMap;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.subscriptions.JavaFxSubscriptions;
+
+public class ObservableMapSource {
+
+    /**
+     * @see rx.observables.JavaFxObservable#fromObservableMap
+     */
+    public static <K, V> Observable<Map<? extends K, ? extends V>> fromObservableMap(ObservableMap<K, V> map) {
+        return Observable.create(new Observable.OnSubscribe<Map<? extends K, ? extends V>>() {
+            @Override
+            public void call(Subscriber<? super Map<? extends K, ? extends V>> subscriber) {
+                subscriber.onNext(map);
+                
+                final MapChangeListener<K, V> listener = new MapChangeListener<K, V>() {
+                    @Override
+                    public void onChanged(Change<? extends K, ? extends V> change) {
+                        subscriber.onNext(change.getMap());
+                    }
+                };
+                
+                map.addListener(listener);
+                
+                subscriber.add(JavaFxSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                    @Override
+                    public void call() {
+                        map.removeListener(listener);
+                    }
+                }));
+            }
+        });
+    }
+}

--- a/src/main/java/rx/javafx/sources/ObservableSetSource.java
+++ b/src/main/java/rx/javafx/sources/ObservableSetSource.java
@@ -1,0 +1,41 @@
+package rx.javafx.sources;
+
+import java.util.Set;
+
+import javafx.collections.ObservableSet;
+import javafx.collections.SetChangeListener;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.subscriptions.JavaFxSubscriptions;
+
+public class ObservableSetSource {
+
+    /**
+     * @see rx.observables.JavaFxObservable#fromObservableSet
+     */
+    public static <T> Observable<Set<? extends T>> fromObservableSet(ObservableSet<T> set) {
+        return Observable.create(new Observable.OnSubscribe<Set<? extends T>>() {
+            @Override
+            public void call(Subscriber<? super Set<? extends T>> subscriber) {
+                subscriber.onNext(set);
+                
+                final SetChangeListener<T> listener = new SetChangeListener<T>() {
+                    @Override
+                    public void onChanged(Change<? extends T> change) {
+                        subscriber.onNext(change.getSet());
+                    }
+                };
+                
+                set.addListener(listener);
+                
+                subscriber.add(JavaFxSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                    @Override
+                    public void call() {
+                        set.removeListener(listener);
+                    }
+                }));
+            }
+        });
+    }
+}

--- a/src/main/java/rx/javafx/sources/WindowEventSource.java
+++ b/src/main/java/rx/javafx/sources/WindowEventSource.java
@@ -1,0 +1,42 @@
+package rx.javafx.sources;
+
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import javafx.event.EventType;
+import javafx.stage.Window;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.schedulers.JavaFxScheduler;
+import rx.subscriptions.JavaFxSubscriptions;
+
+public class WindowEventSource {
+
+    /**
+     * @see rx.observables.JavaFxObservable#fromWindowEvents
+     */
+    public static <T extends Event> Observable<T> fromWindowEvents(final Window source, final EventType<T> eventType) {
+
+        return Observable.create(new Observable.OnSubscribe<T>() {
+            @Override
+            public void call(final Subscriber<? super T> subscriber) {
+                final EventHandler<T> handler = new EventHandler<T>() {
+                    @Override
+                    public void handle(T t) {
+                        subscriber.onNext(t);
+                    }
+                };
+
+                source.addEventHandler(eventType, handler);
+
+                subscriber.add(JavaFxSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                    @Override
+                    public void call() {
+                        source.removeEventHandler(eventType, handler);
+                    }
+                }));
+            }
+
+        }).subscribeOn(JavaFxScheduler.getInstance());
+    }
+}

--- a/src/main/java/rx/observables/JavaFxObservable.java
+++ b/src/main/java/rx/observables/JavaFxObservable.java
@@ -17,15 +17,18 @@ package rx.observables;
 
 
 import java.util.List;
+import java.util.Map;
 
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
 import javafx.event.Event;
 import javafx.event.EventType;
 import javafx.scene.Node;
 import rx.Observable;
 import rx.javafx.sources.NodeEventSource;
 import rx.javafx.sources.ObservableListSource;
+import rx.javafx.sources.ObservableMapSource;
 import rx.javafx.sources.ObservableValueSource;
 
 
@@ -64,5 +67,17 @@ public enum JavaFxObservable {
      */
     public static <T> Observable<List<? extends T>> fromObservableList(final ObservableList<T> list) {
         return ObservableListSource.fromObservableList(list);
+    }
+
+    /**
+     * Create an rx Observable from a javafx ObservableMap.
+     * 
+     * @param map the observed ObservableMap
+     * @param <K>          the type of the keys in the map
+     * @param <V>          the type of the values in the map
+     * @return an Observable emitting map versions as the wrapped ObservableMap changes
+     */
+    public static <K, V> Observable<Map<? extends K, ? extends V>> fromObservableMap(final ObservableMap<K, V> map) {
+        return ObservableMapSource.fromObservableMap(map);
     }
 }

--- a/src/main/java/rx/observables/JavaFxObservable.java
+++ b/src/main/java/rx/observables/JavaFxObservable.java
@@ -18,10 +18,12 @@ package rx.observables;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
+import javafx.collections.ObservableSet;
 import javafx.event.Event;
 import javafx.event.EventType;
 import javafx.scene.Node;
@@ -29,6 +31,7 @@ import rx.Observable;
 import rx.javafx.sources.NodeEventSource;
 import rx.javafx.sources.ObservableListSource;
 import rx.javafx.sources.ObservableMapSource;
+import rx.javafx.sources.ObservableSetSource;
 import rx.javafx.sources.ObservableValueSource;
 
 
@@ -79,5 +82,16 @@ public enum JavaFxObservable {
      */
     public static <K, V> Observable<Map<? extends K, ? extends V>> fromObservableMap(final ObservableMap<K, V> map) {
         return ObservableMapSource.fromObservableMap(map);
+    }
+
+    /**
+     * Create an rx Observable from a javafx ObservableSet.
+     * 
+     * @param set the observed ObservableSet
+     * @param <T>          the type of the elements in the set
+     * @return an Observable emitting set versions as the wrapped ObservableSet changes
+     */
+    public static <T> Observable<Set<? extends T>> fromObservableSet(final ObservableSet<T> set) {
+        return ObservableSetSource.fromObservableSet(set);
     }
 }

--- a/src/main/java/rx/observables/JavaFxObservable.java
+++ b/src/main/java/rx/observables/JavaFxObservable.java
@@ -27,12 +27,14 @@ import javafx.collections.ObservableSet;
 import javafx.event.Event;
 import javafx.event.EventType;
 import javafx.scene.Node;
+import javafx.stage.Window;
 import rx.Observable;
 import rx.javafx.sources.NodeEventSource;
 import rx.javafx.sources.ObservableListSource;
 import rx.javafx.sources.ObservableMapSource;
 import rx.javafx.sources.ObservableSetSource;
 import rx.javafx.sources.ObservableValueSource;
+import rx.javafx.sources.WindowEventSource;
 
 
 public enum JavaFxObservable {
@@ -48,6 +50,17 @@ public enum JavaFxObservable {
      */
     public static <T extends Event> Observable<T> fromNodeEvents(final Node node, final EventType<T> eventType) {
         return NodeEventSource.fromNodeEvents(node, eventType);
+    }
+
+    /**
+     * Creates an observable corresponding to javafx window events.
+     * 
+     * @param window    The target of the window events
+     * @param eventType The type of the observed window events
+     * @return An Observable of window events, appropriately typed
+     */
+    public static <T extends Event> Observable<T> fromWindowEvent(final Window window, final EventType<T> eventType) {
+    	return WindowEventSource.fromWindowEvents(window, eventType);
     }
 
     /**

--- a/src/main/java/rx/observables/JavaFxObservable.java
+++ b/src/main/java/rx/observables/JavaFxObservable.java
@@ -16,12 +16,16 @@
 package rx.observables;
 
 
+import java.util.List;
+
 import javafx.beans.value.ObservableValue;
+import javafx.collections.ObservableList;
 import javafx.event.Event;
 import javafx.event.EventType;
 import javafx.scene.Node;
 import rx.Observable;
 import rx.javafx.sources.NodeEventSource;
+import rx.javafx.sources.ObservableListSource;
 import rx.javafx.sources.ObservableValueSource;
 
 
@@ -49,5 +53,16 @@ public enum JavaFxObservable {
      */
     public static <T> Observable<T> fromObservableValue(final ObservableValue<T> fxObservable) {
         return ObservableValueSource.fromObservableValue(fxObservable);
+    }
+
+    /**
+     * Create an rx Observable from a javafx ObservableList.
+     * 
+     * @param list the observed ObservableList
+     * @param <T>          the type of the elements in the list
+     * @return an Observable emitting list versions as the wrapped ObservableList changes
+     */
+    public static <T> Observable<List<? extends T>> fromObservableList(final ObservableList<T> list) {
+        return ObservableListSource.fromObservableList(list);
     }
 }


### PR DESCRIPTION
I have been using RxJavaFX for a couple of months now and often came across limitations of this library. To solve these limitations, I added a number of wrappers that must be in this library to support the collaboration between RxJava and JavaFX more optimally.

First of all, besides many properties/`ObservableValues`, JavaFX has a number of observable collections: `ObservableList`, `ObservableMap` and `ObservableSet` that can be turned into Rx Observables. Every time a collection fires a change event, a new snapshot of that collection is put into the Rx Observable.

Secondly, the RxJavaFX library was already capable of fetching all events of a certain type fired from a specific `Node`. However, this was not possible for something like a `Stage` or other type of `Window`. Therefore I added a wrapper that supports fetching a certain type of events from a `Window`.

Let me know what you think about this and what improvements there could be on the new code.
