### PR TITLE
update maven central URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ RxJavaFX is a simple API to convert JavaFX events into RxJava Observables. It al
 
 ## Binaries
 
-Binaries and dependency information for Maven, Ivy, Gradle and others can be found at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Cio.reactivex.rxjava-reactive-streams).
+Binaries and dependency information for Maven, Ivy, Gradle and others can be found at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Cio.reactivex.rxjavafx).
 
 Example for Maven:
 


### PR DESCRIPTION
Update the "maven search url" http://search.maven.org/#search%7Cga%7C1%7Cio.reactivex.rxjavafx instead of http://search.maven.org/#search%7Cga%7C1%7Cio.reactivex.rxjava-reactive-streams
