### PR TITLE
Implement fromObservableValueChanges

### DIFF
--- a/src/main/java/rx/javafx/sources/Change.java
+++ b/src/main/java/rx/javafx/sources/Change.java
@@ -1,0 +1,17 @@
+package rx.javafx.sources;
+
+public final class Change<T> {
+    private final T oldVal;
+    private final T newVal;
+
+    public Change(T oldVal, T newVal) {
+        this.oldVal = oldVal;
+        this.newVal = newVal;
+    }
+    public T getOldVal() {
+        return oldVal;
+    }
+    public T getNewVal() {
+        return newVal;
+    }
+}

--- a/src/main/java/rx/observables/JavaFxObservable.java
+++ b/src/main/java/rx/observables/JavaFxObservable.java
@@ -21,6 +21,7 @@ import javafx.event.Event;
 import javafx.event.EventType;
 import javafx.scene.Node;
 import rx.Observable;
+import rx.javafx.sources.Change;
 import rx.javafx.sources.NodeEventSource;
 import rx.javafx.sources.ObservableValueSource;
 
@@ -49,5 +50,16 @@ public enum JavaFxObservable {
      */
     public static <T> Observable<T> fromObservableValue(final ObservableValue<T> fxObservable) {
         return ObservableValueSource.fromObservableValue(fxObservable);
+    }
+
+    /**
+     * Create an rx Observable from a javafx ObservableValue, and emits changes with old and new value pairs
+     *
+     * @param fxObservable the observed ObservableValue
+     * @param <T>          the type of the observed value
+     * @return an Observable emitting values as the wrapped ObservableValue changes
+     */
+    public static <T> Observable<Change<T>> fromObservableValueChanges(final ObservableValue<T> fxObservable) {
+        return ObservableValueSource.fromObservableValueChanges(fxObservable);
     }
 }


### PR DESCRIPTION
Implementation for #18. Callling `JavaFxObservable.fromObservableValueChanges()` will return an `Observable<Change<T>>`. The `Change` contains the old value and new value which are paired into a single emission.
