### PR TITLE
allow a custom null-sentinel value

### DIFF
--- a/src/main/java/io/reactivex/rxjavafx/observables/JavaFxObservable.java
+++ b/src/main/java/io/reactivex/rxjavafx/observables/JavaFxObservable.java
@@ -69,6 +69,18 @@ public enum JavaFxObservable {
      * Create an rx Observable from a JavaFX ObservableValue
      *
      * @param fxObservable the observed ObservableValue
+     * @param nullSentinel the default sentinel value emitted when the observable is null
+     * @param <T>          the type of the observed value
+     * @return an Observable emitting values as the wrapped ObservableValue changes, null will be replaces with nullSentinel
+     */
+    public static <T> Observable<T> valuesOf(final ObservableValue<T> fxObservable, final T nullSentinel) {
+        return ObservableValueSource.fromObservableValue(fxObservable, nullSentinel);
+    }
+
+    /**
+     * Create an rx Observable from a JavaFX ObservableValue
+     *
+     * @param fxObservable the observed ObservableValue
      * @param <T>          the type of the observed value
      * @return an Observable emitting nullable values as the wrapped ObservableValue changes
      */


### PR DESCRIPTION
Add overloads which allow users to specify a custom default value, which will be used as sentinel when the ObservableValue is changed to null.
There were lot of discussions how to handle null values during the 2.0 transition.
The alternatives are wrapping every value in Optional<> or using a sentinel instance as replacement.
Whereas the approach with Optional<> is a better design for external APIs the sentinel might be easier to use and reduces allocations. They are both independent and valid approaches, thus I'm adding the missing one.