### PR TITLE
add nullable Bindings

### DIFF
--- a/src/main/java/io/reactivex/rxjavafx/observers/BindingSubscriber.java
+++ b/src/main/java/io/reactivex/rxjavafx/observers/BindingSubscriber.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2017 Netflix, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@ package io.reactivex.rxjavafx.observers;
 import com.sun.javafx.binding.ExpressionHelper;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
 import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Binding;
 import javafx.beans.value.ChangeListener;
@@ -26,23 +27,32 @@ import javafx.collections.ObservableList;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+final class BindingSubscriber<T, S> implements Subscriber<T>, ObservableValue<S>, Binding<S> {
 
-final class BindingSubscriber<T> implements Subscriber<T>, ObservableValue<T>, Binding<T> {
-
-    private final Consumer<Throwable> onError;
-    private final ConnectableFlowable<T> flowable;
+    private final Function<T, S>         unmaskingFunction;
+    private final Consumer<Throwable>    onError;
+    private final ConnectableFlowable<T> obs;
     private boolean connected = false;
-    private Subscription subscription;
-    private ExpressionHelper<T> helper;
-    private T value;
+    private Subscription        subscription;
+    private ExpressionHelper<S> helper;
+    private S                   value;
 
-    BindingSubscriber(Consumer<Throwable> onError) {
-        this.flowable = null;
+    BindingSubscriber(Function<T, S> unmaskingFunction, Consumer<Throwable> onError) {
+        this.unmaskingFunction = unmaskingFunction;
         this.onError = onError;
+        this.obs = null;
     }
-    BindingSubscriber(ConnectableFlowable<T> flowable, Consumer<Throwable> onError) {
-        this.flowable = flowable;
+
+    BindingSubscriber(Function<T, S> unmaskingFunction, ConnectableFlowable<T> obs, Consumer<Throwable> onError) {
+        this.unmaskingFunction = unmaskingFunction;
         this.onError = onError;
+        this.obs = obs;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        this.subscription = s;
+        this.subscription.request(Long.MAX_VALUE);
     }
 
     @Override
@@ -60,24 +70,24 @@ final class BindingSubscriber<T> implements Subscriber<T>, ObservableValue<T>, B
     }
 
     @Override
-    public void onSubscribe(Subscription s) {
-        subscription = s;
-        subscription.request(Long.MAX_VALUE);
+    public void onNext(T t) {
+        try {
+            value = unmaskingFunction.apply(t);
+            fireValueChangedEvent();
+        } catch (Exception e) {
+            onError(e);
+        }
     }
 
     @Override
-    public void onNext(T t) {
-        value = t;
-        fireValueChangedEvent();
-    }
-    @Override
-    public T getValue() {
-        if (!connected && flowable != null) {
-            flowable.connect();
+    public S getValue() {
+        if (!connected && obs != null) {
+            obs.connect();
             connected = true;
         }
         return value;
     }
+
     @Override
     public boolean isValid() {
         return true;
@@ -112,7 +122,7 @@ final class BindingSubscriber<T> implements Subscriber<T>, ObservableValue<T>, B
      * {@inheritDoc}
      */
     @Override
-    public void addListener(ChangeListener<? super T> listener) {
+    public void addListener(ChangeListener<? super S> listener) {
         helper = ExpressionHelper.addListener(helper, this, listener);
     }
 
@@ -128,13 +138,13 @@ final class BindingSubscriber<T> implements Subscriber<T>, ObservableValue<T>, B
      * {@inheritDoc}
      */
     @Override
-    public void removeListener(ChangeListener<? super T> listener) {
+    public void removeListener(ChangeListener<? super S> listener) {
         helper = ExpressionHelper.removeListener(helper, listener);
     }
 
     /**
      * Notify the currently registered observers of a value change.
-     *
+     * <p>
      * This implementation will ignore all adds and removes of observers that
      * are done while a notification is processed. The changes take effect in
      * the following call to fireValueChangedEvent.

--- a/src/main/java/io/reactivex/rxjavafx/observers/JavaFxObserver.java
+++ b/src/main/java/io/reactivex/rxjavafx/observers/JavaFxObserver.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2017 Netflix, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,42 +18,129 @@ package io.reactivex.rxjavafx.observers;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.observables.ConnectableObservable;
+import io.reactivex.rxjavafx.observables.JavaFxObservable;
 import javafx.beans.binding.Binding;
+import javafx.beans.value.ObservableValue;
+
+import java.util.Optional;
 
 public enum JavaFxObserver {
     ;//no instances
+
     /**
      * Turns an Observable into an eager JavaFX Binding that subscribes immediately to the Observable. Calling the Binding's dispose() method will handle the unsubscription.
      */
     public static <T> Binding<T> toBinding(Observable<T> obs) {
-        BindingObserver<T> bindingObserver = new BindingObserver<>(e -> {});
-        obs.subscribe(bindingObserver);
-        return bindingObserver;
+        return toBinding(obs, JavaFxObserver::onError);
     }
+
     /**
      * Turns an Observable into an eager JavaFX Binding that subscribes immediately to the Observable. Calling the Binding's dispose() method will handle the unsubscription.
      */
-    public static <T> Binding<T> toBinding(Observable<T> obs, Consumer<Throwable> onErrorAction ) {
-        BindingObserver<T> bindingObserver = new BindingObserver<>(onErrorAction);
+    public static <T> Binding<T> toBinding(Observable<T> obs, Consumer<Throwable> onErrorAction) {
+        BindingObserver<T, T> bindingObserver = new BindingObserver<>(t -> t, onErrorAction);
         obs.subscribe(bindingObserver);
         return bindingObserver;
     }
+
+    /**
+     * Turns an Observable into an eager JavaFX Binding that subscribes immediately to the Observable. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#valuesOf(ObservableValue, Object)} and emits null when the sentinel is encountered.
+     */
+    public static <T> Binding<T> toNullBinding(Observable<T> obs, T nullSentinel) {
+        return toNullBinding(obs, nullSentinel, JavaFxObserver::onError);
+    }
+
+    /**
+     * Turns an Observable into an eager JavaFX Binding that subscribes immediately to the Observable. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#valuesOf(ObservableValue, Object)} and emits null when the sentinel is encountered.
+     */
+    public static <T> Binding<T> toNullBinding(Observable<T> obs, T nullSentinel, Consumer<Throwable> onErrorAction) {
+        if (nullSentinel == null) {
+            throw new NullPointerException("The null value sentinel must not be null.");
+        }
+        BindingObserver<T, T> bindingObserver = new BindingObserver<>(t -> t == nullSentinel ? null : t, onErrorAction);
+        obs.subscribe(bindingObserver);
+        return bindingObserver;
+    }
+
+    /**
+     * Turns an Observable into an eager JavaFX Binding that subscribes immediately to the Observable. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#nullableValuesOf(ObservableValue)} and emits null when the value is not present.
+     */
+    public static <T> Binding<T> toNullableBinding(Observable<Optional<T>> obs) {
+        return toNullableBinding(obs, JavaFxObserver::onError);
+    }
+
+    /**
+     * Turns an Observable into an eager JavaFX Binding that subscribes immediately to the Observable. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#nullableValuesOf(ObservableValue)} and emits null when the value is not present.
+     */
+    public static <T> Binding<T> toNullableBinding(Observable<Optional<T>> obs, Consumer<Throwable> onErrorAction) {
+        BindingObserver<Optional<T>, T> bindingObserver = new BindingObserver<>(o -> o.orElse(null), onErrorAction);
+        obs.subscribe(bindingObserver);
+        return bindingObserver;
+    }
+
     /**
      * Turns an Observable into an lazy JavaFX Binding that subscribes to the Observable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
      */
     public static <T> Binding<T> toLazyBinding(Observable<T> obs) {
-        ConnectableObservable<T> published = obs.publish();
-        BindingObserver<T> bindingObserver = new BindingObserver<>(published, e -> {});
-        published.subscribe(bindingObserver);
-        return bindingObserver;
+        return toLazyBinding(obs, JavaFxObserver::onError);
     }
+
     /**
      * Turns an Observable into an eager JavaFX Binding that subscribes to the Observable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
      */
-    public static <T> Binding<T> toLazyBinding(Observable<T> obs, Consumer<Throwable> onErrorAction ) {
+    public static <T> Binding<T> toLazyBinding(Observable<T> obs, Consumer<Throwable> onErrorAction) {
         ConnectableObservable<T> published = obs.publish();
-        BindingObserver<T> bindingObserver = new BindingObserver<>(published,onErrorAction);
+        BindingObserver<T, T> bindingObserver = new BindingObserver<>(t -> t, published, onErrorAction);
         published.subscribe(bindingObserver);
         return bindingObserver;
+    }
+
+    /**
+     * Turns an Observable into an eager JavaFX Binding that subscribes to the Observable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#valuesOf(ObservableValue, Object)} and emits null when the sentinel is encountered.
+     */
+    public static <T> Binding<T> toLazyNullBinding(Observable<T> obs, T nullSentinel) {
+        return toLazyNullBinding(obs, nullSentinel, JavaFxObserver::onError);
+    }
+
+    /**
+     * Turns an Observable into an eager JavaFX Binding that subscribes to the Observable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#valuesOf(ObservableValue, Object)} and emits null when the sentinel is encountered.
+     */
+    public static <T> Binding<T> toLazyNullBinding(Observable<T> obs, T nullSentinel, Consumer<Throwable> onErrorAction) {
+        if (nullSentinel == null) {
+            throw new NullPointerException("The null value sentinel must not be null.");
+        }
+        ConnectableObservable<T> published = obs.publish();
+        BindingObserver<T, T> bindingObserver = new BindingObserver<>(t -> t == nullSentinel ? null : t, published, onErrorAction);
+        published.subscribe(bindingObserver);
+        return bindingObserver;
+    }
+
+    /**
+     * Turns an Observable into an lazy JavaFX Binding that subscribes to the Observable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#nullableValuesOf(ObservableValue)} and emits null when the value is not present.
+     */
+    public static <T> Binding<T> toLazyNullableBinding(Observable<Optional<T>> obs) {
+        return toLazyNullableBinding(obs, JavaFxObserver::onError);
+    }
+
+    /**
+     * Turns an Observable into an lazy JavaFX Binding that subscribes to the Observable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#nullableValuesOf(ObservableValue)} and emits null when the value is not present.
+     */
+    public static <T> Binding<T> toLazyNullableBinding(Observable<Optional<T>> obs, Consumer<Throwable> onErrorAction) {
+        ConnectableObservable<Optional<T>> published = obs.publish();
+        BindingObserver<Optional<T>, T> bindingObserver = new BindingObserver<>(o -> o.orElse(null), published, onErrorAction);
+        published.subscribe(bindingObserver);
+        return bindingObserver;
+    }
+
+    private static void onError(Throwable t) {
+        // nothing
     }
 }

--- a/src/main/java/io/reactivex/rxjavafx/observers/JavaFxSubscriber.java
+++ b/src/main/java/io/reactivex/rxjavafx/observers/JavaFxSubscriber.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2017 Netflix, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,43 +18,129 @@ package io.reactivex.rxjavafx.observers;
 import io.reactivex.Flowable;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.Consumer;
+import io.reactivex.rxjavafx.observables.JavaFxObservable;
 import javafx.beans.binding.Binding;
+import javafx.beans.value.ObservableValue;
+
+import java.util.Optional;
+
 public enum JavaFxSubscriber {
     ;//no instances
 
     /**
-     * Turns a Flowable into an eager JavaFX Binding that subscribes immediately to the Observable. Calling the Binding's dispose() method will handle the unsubscription.
+     * Turns an Flowable into an eager JavaFX Binding that subscribes immediately to the Flowable. Calling the Binding's dispose() method will handle the unsubscription.
      */
-    public static <T> Binding<T> toBinding(Flowable<T> obs) {
-        BindingSubscriber<T> bindingSubscriber = new BindingSubscriber<>(e -> {});
-        obs.subscribe(bindingSubscriber);
-        return bindingSubscriber;
+    public static <T> Binding<T> toBinding(Flowable<T> flowable) {
+        return toBinding(flowable, JavaFxSubscriber::onError);
     }
+
     /**
-     * Turns a Flowable into an eager JavaFX Binding that subscribes immediately to the Observable. Calling the Binding's dispose() method will handle the unsubscription.
+     * Turns an Flowable into an eager JavaFX Binding that subscribes immediately to the Flowable. Calling the Binding's dispose() method will handle the unsubscription.
      */
-    public static <T> Binding<T> toBinding(Flowable<T> obs, Consumer<Throwable> onErrorAction ) {
-        BindingSubscriber<T> bindingSubscriber = new BindingSubscriber<>(onErrorAction);
-        obs.subscribe(bindingSubscriber);
+    public static <T> Binding<T> toBinding(Flowable<T> flowable, Consumer<Throwable> onErrorAction) {
+        BindingSubscriber<T, T> bindingSubscriber = new BindingSubscriber<>(t -> t, onErrorAction);
+        flowable.subscribe(bindingSubscriber);
         return bindingSubscriber;
     }
 
     /**
-     * Turns a Flowable into an lazy JavaFX Binding that subscribes to the Observable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     * Turns an Flowable into an eager JavaFX Binding that subscribes immediately to the Flowable. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#valuesOf(ObservableValue, Object)} and emits null when the sentinel is encountered.
+     */
+    public static <T> Binding<T> toNullBinding(Flowable<T> flowable, T nullSentinel) {
+        return toNullBinding(flowable, nullSentinel, JavaFxSubscriber::onError);
+    }
+
+    /**
+     * Turns an Flowable into an eager JavaFX Binding that subscribes immediately to the Flowable. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#valuesOf(ObservableValue, Object)} and emits null when the sentinel is encountered.
+     */
+    public static <T> Binding<T> toNullBinding(Flowable<T> flowable, T nullSentinel, Consumer<Throwable> onErrorAction) {
+        if (nullSentinel == null) {
+            throw new NullPointerException("The null value sentinel must not be null.");
+        }
+        BindingSubscriber<T, T> bindingSubscriber = new BindingSubscriber<>(t -> t == nullSentinel ? null : t, onErrorAction);
+        flowable.subscribe(bindingSubscriber);
+        return bindingSubscriber;
+    }
+
+    /**
+     * Turns an Flowable into an eager JavaFX Binding that subscribes immediately to the Flowable. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#nullableValuesOf(ObservableValue)} and emits null when the value is not present.
+     */
+    public static <T> Binding<T> toNullableBinding(Flowable<Optional<T>> flowable) {
+        return toNullableBinding(flowable, JavaFxSubscriber::onError);
+    }
+
+    /**
+     * Turns an Flowable into an eager JavaFX Binding that subscribes immediately to the Flowable. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#nullableValuesOf(ObservableValue)} and emits null when the value is not present.
+     */
+    public static <T> Binding<T> toNullableBinding(Flowable<Optional<T>> flowable, Consumer<Throwable> onErrorAction) {
+        BindingSubscriber<Optional<T>, T> bindingSubscriber = new BindingSubscriber<>(o -> o.orElse(null), onErrorAction);
+        flowable.subscribe(bindingSubscriber);
+        return bindingSubscriber;
+    }
+
+    /**
+     * Turns an Flowable into an lazy JavaFX Binding that subscribes to the Flowable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
      */
     public static <T> Binding<T> toLazyBinding(Flowable<T> flowable) {
+        return toLazyBinding(flowable, JavaFxSubscriber::onError);
+    }
+
+    /**
+     * Turns an Flowable into an eager JavaFX Binding that subscribes to the Flowable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     */
+    public static <T> Binding<T> toLazyBinding(Flowable<T> flowable, Consumer<Throwable> onErrorAction) {
         ConnectableFlowable<T> published = flowable.publish();
-        BindingSubscriber<T> bindingSubscriber = new BindingSubscriber<>(published, e -> {});
+        BindingSubscriber<T, T> bindingSubscriber = new BindingSubscriber<>(t -> t, published, onErrorAction);
         published.subscribe(bindingSubscriber);
         return bindingSubscriber;
     }
+
     /**
-     * Turns a Flowable into an eager JavaFX Binding that subscribes to the Observable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     * Turns an Flowable into an eager JavaFX Binding that subscribes to the Flowable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#valuesOf(ObservableValue, Object)} and emits null when the sentinel is encountered.
      */
-    public static <T> Binding<T> toLazyBinding(Flowable<T> flowable, Consumer<Throwable> onErrorAction ) {
+    public static <T> Binding<T> toLazyNullBinding(Flowable<T> flowable, T nullSentinel) {
+        return toLazyNullBinding(flowable, nullSentinel, JavaFxSubscriber::onError);
+    }
+
+    /**
+     * Turns an Flowable into an eager JavaFX Binding that subscribes to the Flowable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#valuesOf(ObservableValue, Object)} and emits null when the sentinel is encountered.
+     */
+    public static <T> Binding<T> toLazyNullBinding(Flowable<T> flowable, T nullSentinel, Consumer<Throwable> onErrorAction) {
+        if (nullSentinel == null) {
+            throw new NullPointerException("The null value sentinel must not be null.");
+        }
         ConnectableFlowable<T> published = flowable.publish();
-        BindingSubscriber<T> bindingSubscriber = new BindingSubscriber<>(published,onErrorAction);
+        BindingSubscriber<T, T> bindingSubscriber = new BindingSubscriber<>(t -> t == nullSentinel ? null : t, published, onErrorAction);
         published.subscribe(bindingSubscriber);
         return bindingSubscriber;
+    }
+
+    /**
+     * Turns an Flowable into an lazy JavaFX Binding that subscribes to the Flowable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#nullableValuesOf(ObservableValue)} and emits null when the value is not present.
+     */
+    public static <T> Binding<T> toLazyNullableBinding(Flowable<Optional<T>> flowable) {
+        return toLazyNullableBinding(flowable, JavaFxSubscriber::onError);
+    }
+
+    /**
+     * Turns an Flowable into an lazy JavaFX Binding that subscribes to the Flowable when its getValue() is called. Calling the Binding's dispose() method will handle the unsubscription.
+     * This variant unmasks a nullable value as in {@link JavaFxObservable#nullableValuesOf(ObservableValue)} and emits null when the value is not present.
+     */
+    public static <T> Binding<T> toLazyNullableBinding(Flowable<Optional<T>> flowable, Consumer<Throwable> onErrorAction) {
+        ConnectableFlowable<Optional<T>> published = flowable.publish();
+        BindingSubscriber<Optional<T>, T> bindingSubscriber = new BindingSubscriber<>(o -> o.orElse(null), published, onErrorAction);
+        published.subscribe(bindingSubscriber);
+        return bindingSubscriber;
+    }
+
+    private static void onError(Throwable t) {
+        // nothing
     }
 }


### PR DESCRIPTION
add overloads to JavaFxObserver and JavaFxSubscriber which allow to unmask null values in an Optional<T> or guarded by a sentinel as counterpart to JavaFxObservable.nullableValuesOf