### PR TITLE
do not ignore exceptions, call RxJavaPlugins.onError instead

### DIFF
--- a/src/main/java/io/reactivex/rxjavafx/observers/JavaFxObserver.java
+++ b/src/main/java/io/reactivex/rxjavafx/observers/JavaFxObserver.java
@@ -15,14 +15,15 @@
  */
 package io.reactivex.rxjavafx.observers;
 
+import java.util.Optional;
+
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.observables.ConnectableObservable;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.rxjavafx.observables.JavaFxObservable;
 import javafx.beans.binding.Binding;
 import javafx.beans.value.ObservableValue;
-
-import java.util.Optional;
 
 public enum JavaFxObserver {
     ;//no instances
@@ -141,6 +142,6 @@ public enum JavaFxObserver {
     }
 
     private static void onError(Throwable t) {
-        // nothing
+        RxJavaPlugins.onError(t);
     }
 }

--- a/src/main/java/io/reactivex/rxjavafx/observers/JavaFxSubscriber.java
+++ b/src/main/java/io/reactivex/rxjavafx/observers/JavaFxSubscriber.java
@@ -18,6 +18,7 @@ package io.reactivex.rxjavafx.observers;
 import io.reactivex.Flowable;
 import io.reactivex.flowables.ConnectableFlowable;
 import io.reactivex.functions.Consumer;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.rxjavafx.observables.JavaFxObservable;
 import javafx.beans.binding.Binding;
 import javafx.beans.value.ObservableValue;
@@ -141,6 +142,6 @@ public enum JavaFxSubscriber {
     }
 
     private static void onError(Throwable t) {
-        // nothing
+        RxJavaPlugins.onError(t);
     }
 }


### PR DESCRIPTION
This behavior corresponds to the RxJava2 behavior:
https://github.com/ReactiveX/RxJava/wiki/What%27s-different-in-2.0#error-handling

https://github.com/ReactiveX/RxJavaFX/issues/81