### PR TITLE
fix(gradle): tests not executed because of issues with Gradle 4 and Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,10 +53,6 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.8.5'
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.10.2' //version required
-}
-
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.main.allSource

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 4 and Java 11 did not work property together: tests are not executed.
Gradle fixed this issue with Gradle 5.
See: gradle/gradle#7059

This patch makes use of Gradle 5 to able test executions (that still fail because of another issue I will pore over).