### PR TITLE
fix(test): Each test class that uses JFX must init the JFX toolkit

### DIFF
--- a/src/test/java/io/reactivex/rxjavafx/schedulers/JavaFxSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjavafx/schedulers/JavaFxSchedulerTest.java
@@ -58,10 +58,13 @@ public final class JavaFxSchedulerTest {
         }
     }
 
-    @BeforeClass
-    public static void initJFX() {
-        javafx.application.Platform.startup(() ->{});
-    }
+	@BeforeClass
+	public static void initJFX() {
+		try {
+			javafx.application.Platform.startup(() ->{});
+		}catch(final IllegalStateException ignore) {
+		}
+	}
 
     @Test
     public void testPeriodicScheduling() throws Exception {

--- a/src/test/java/io/reactivex/rxjavafx/sources/JavaFxObservableTest.java
+++ b/src/test/java/io/reactivex/rxjavafx/sources/JavaFxObservableTest.java
@@ -36,6 +36,14 @@ import static org.junit.Assert.assertTrue;
 
 public final class JavaFxObservableTest {
 
+	@BeforeClass
+	public static void initJFX() {
+		try {
+			javafx.application.Platform.startup(() ->{});
+		}catch(final IllegalStateException ignore) {
+		}
+	}
+
     @Test
     public void testIntervalSource() {
 


### PR DESCRIPTION
When executing the class `JavaFxObservableTest` alone several tests fail: the JFX tooltkit is not initialised.
The test class `JavaFxSchedulerTest` has a method `initJFX` that initialises the JFX toolkit. Yet, if `JavaFxObservableTest` is executed before this class, the tests will fail (which appends sometimes with gradle `build`).

Another change: if the toolkit has been already initialised by another test class, an annoying exception will be raised (`IllegalStateException`). Need to try/catch to ignore this exception.