### PR TITLE
Corrected xvfb breaking change for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ jdk:
 sudo: false
 # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 
-before_install:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
+services:
+  - xvfb
 
 # script for build and release via Travis to Bintray
 script: gradle/buildViaTravis.sh


### PR DESCRIPTION
Now Travis can be finished.

See the new doc [here](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui).